### PR TITLE
Extract resources into nested modules organized by their lifecycle

### DIFF
--- a/modules/32_vault_kms/README.md
+++ b/modules/32_vault_kms/README.md
@@ -1,0 +1,8 @@
+# Vault KMS Key Ring
+
+The Vault keyring is used to initialize vault and encrypt the unseal keys.
+This keyring is persistent and separated out into it's own module so that Vault
+compute resources can be ephemeral.
+
+This allows the key ring to persist when the compute resources go through a
+destroy / apply cycle.

--- a/modules/32_vault_kms/main.tf
+++ b/modules/32_vault_kms/main.tf
@@ -1,0 +1,42 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+resource "random_id" "name" {
+  byte_length = 2
+}
+
+locals {
+  kms_keyring = var.kms_keyring == "" ? "vault-${random_id.name.hex}" : var.kms_keyring
+}
+
+# Create the KMS key ring
+resource "google_kms_key_ring" "vault" {
+  name     = local.kms_keyring
+  location = var.region
+  project  = var.project_id
+}
+
+# Create the crypto key for encrypting init keys
+resource "google_kms_crypto_key" "vault-init" {
+  name            = var.kms_crypto_key
+  key_ring        = google_kms_key_ring.vault.id
+  rotation_period = "604800s"
+
+  version_template {
+    algorithm        = "GOOGLE_SYMMETRIC_ENCRYPTION"
+    protection_level = upper(var.kms_protection_level)
+  }
+}

--- a/modules/32_vault_kms/outputs.tf
+++ b/modules/32_vault_kms/outputs.tf
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2020 Open Infrastructure Services, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+output "vault_kms_keyring" {
+  description = "The vault keyring used to unseal vault storage in GCS.  This keyring should persist with a long term lifecycle."
+  value       = google_kms_key_ring.vault.id
+}
+
+output "vault_kms_key_init" {
+  description = "The KMS key used to unseal vault storage in GCS.  This keyring should persist with a long term lifecycle."
+  value       = google_kms_crypto_key.vault-init.id
+}

--- a/modules/32_vault_kms/variables.tf
+++ b/modules/32_vault_kms/variables.tf
@@ -1,0 +1,49 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "project_id" {
+  description = "Project ID to manage resources within."
+  type        = string
+}
+
+variable "region" {
+  description = "Region in which to create resources."
+  type        = string
+  default     = "us-east4"
+}
+
+#
+#
+# KMS
+# --------------------
+
+variable "kms_keyring" {
+  description = "KMS keyring used to encrypt Vault init keys.  This keyring must persist, otherwise Vault automatic unseal will fail.  Note, keyrings cannot be deleted.  The default generates a unique name."
+  type        = string
+  default     = ""
+}
+
+variable "kms_crypto_key" {
+  description = "The name of the Cloud KMS Key used for encrypting initial TLS certificates and for configuring Vault auto-unseal. Terraform will create this key."
+  type        = string
+  default     = "vault-init"
+}
+
+variable "kms_protection_level" {
+  description = "The protection level to use for the KMS crypto key."
+  type        = string
+  default     = "software"
+}

--- a/modules/33_vault_tls/README.md
+++ b/modules/33_vault_tls/README.md
@@ -1,0 +1,6 @@
+# Vault TLS Management
+
+Vault TLS certificates persist, so manage them in a separate nested module.
+
+This allows the resources to persist when the compute resources go through a
+destroy / apply cycle.

--- a/modules/33_vault_tls/outputs.tf
+++ b/modules/33_vault_tls/outputs.tf
@@ -1,0 +1,27 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+output "ca_cert_pem" {
+  description = "CA certificate used to verify Vault TLS client connections."
+  value       = tls_self_signed_cert.root.*.cert_pem
+  sensitive   = false
+}
+
+output "ca_key_pem" {
+  description = "Private key for the CA."
+  value       = tls_private_key.root.*.private_key_pem
+  sensitive   = true
+}

--- a/modules/33_vault_tls/variables.tf
+++ b/modules/33_vault_tls/variables.tf
@@ -1,0 +1,104 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "manage_tls" {
+  description = "Set to `false` if you'd like to manage and upload your own TLS files. See `Managing TLS` for more details"
+  type        = bool
+  default     = true
+}
+
+variable "tls_save_ca_to_disk" {
+  description = "Save the CA public certificate on the local filesystem. The CA is always stored in GCS, but this option also saves it to the filesystem."
+  type        = bool
+  default     = true
+}
+
+variable "tls_ca_subject" {
+  description = "The `subject` block for the root CA certificate."
+  type = object({
+    common_name         = string,
+    organization        = string,
+    organizational_unit = string,
+    street_address      = list(string),
+    locality            = string,
+    province            = string,
+    country             = string,
+    postal_code         = string,
+  })
+
+  default = {
+    common_name         = "Example Inc. Root"
+    organization        = "Example, Inc"
+    organizational_unit = "Department of Certificate Authority"
+    street_address      = ["123 Example Street"]
+    locality            = "The Intranet"
+    province            = "CA"
+    country             = "US"
+    postal_code         = "95559-1227"
+  }
+}
+
+variable "tls_dns_names" {
+  description = "List of DNS names added to the Vault server self-signed certificate"
+  type        = list(string)
+  default     = ["vault.example.net"]
+}
+
+variable "tls_ips" {
+  description = "List of IP addresses added to the Vault server self-signed certificate"
+  type        = list(string)
+  default     = ["127.0.0.1"]
+}
+
+variable "tls_cn" {
+  description = "The TLS Common Name for the TLS certificates"
+  type        = string
+  default     = "vault.example.net"
+}
+
+variable "tls_ou" {
+  description = "The TLS Organizational Unit for the TLS certificate"
+  type        = string
+  default     = "IT Security Operations"
+}
+
+variable "vault_tls_key_filename" {
+  description = "Encrypted and base64 encoded GCS object path within the vault_tls_bucket. This is the Vault TLS private key."
+  type        = string
+  default     = "vault.key.enc"
+}
+
+variable "vault_tls_cert_filename" {
+  description = "GCS object path within the vault_tls_bucket. This is the vault server certificate."
+  type        = string
+  default     = "vault.crt"
+}
+
+variable "vault_ca_cert_filename" {
+  description = "GCS object path within the vault_tls_bucket. This is the root CA certificate."
+  type        = string
+  default     = "ca.crt"
+}
+
+variable "vault_tls_bucket" {
+  description = "GCS Bucket to store TLS certificates in."
+  type        = string
+}
+
+variable "vault_kms_key_tls" {
+  description = "KMS key used to encrypt TLS secrets.  The same keyring as the vault init keyring may be used here.  Full path."
+  type        = string
+}

--- a/modules/42_vault_iam/README.md
+++ b/modules/42_vault_iam/README.md
@@ -1,0 +1,8 @@
+# Vault IAM Policies
+
+This nested module manages IAM policies which are expected to have a long
+lifecycle separate from the ephemeral compute resources.
+
+The policies grant the vault-server service account access to the backed data
+bucket and KMS key.  Additionally the vault-admin service account is granted
+access to the terraform state bucket used to manage vault.

--- a/modules/42_vault_iam/variables.tf
+++ b/modules/42_vault_iam/variables.tf
@@ -1,0 +1,81 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "project_id" {
+  description = "Project ID to contain managed resources."
+  type        = string
+}
+
+variable "kms_keyring" {
+  description = "Name of the Cloud KMS KeyRing for unsealing vault and TLS keys.  If blank, defaults to `projects/PROJECT_ID/locations/us/keyRings/vault`.  For example, 'projects/myproject/locations/us-west1/keyRings/vault'"
+  type        = string
+  default     = ""
+}
+
+variable "kms_crypto_key" {
+  description = "The name of the Cloud KMS Key used for encrypting initial TLS certificates and for configuring Vault auto-unseal."
+  type        = string
+  default     = "vault-init"
+}
+
+variable "vault_service_account_email" {
+  description = "Vault service account email"
+  type        = string
+}
+
+variable "service_account_project_iam_roles" {
+  description = "List of IAM roles for the Vault admin service account to function. If you need to add additional roles, update `service_account_project_additional_iam_roles` instead."
+  type        = list(string)
+  default     = [
+    "roles/logging.logWriter",
+    "roles/monitoring.metricWriter",
+    "roles/monitoring.viewer",
+  ]
+}
+
+variable "service_account_project_additional_iam_roles" {
+  type    = list(string)
+  default = []
+
+  description = "List of custom IAM roles to add to the project."
+}
+
+variable "service_account_storage_bucket_iam_roles" {
+  description = "List of IAM roles for the Vault admin service account to have on the storage bucket."
+  type = list(string)
+
+  default = [
+    "roles/storage.legacyBucketReader",
+    "roles/storage.objectAdmin",
+  ]
+}
+
+variable "manage_tls" {
+  description = "Set to `false` if you'd like to manage and upload your own TLS files. See `Managing TLS` for more details"
+  type        = bool
+  default     = true
+}
+
+variable "vault_storage_bucket" {
+  description = "Storage bucket name where the backend is configured."
+  type        = string
+}
+
+variable "vault_tls_bucket" {
+  description = "GCS Bucket override where Vault will expect TLS certificates are stored."
+  type        = string
+  default     = ""
+}

--- a/modules/55_vault_cluster/README.md
+++ b/modules/55_vault_cluster/README.md
@@ -1,0 +1,16 @@
+# Vault Cluster
+
+This module manages the minimum compute resources to achieve a HA Vault Cluster
+in GCP.  The primary design goal is to enable the cluster to be ephemeral while
+persisting the API address, vault data, TLS certificates, and auto-unseal KMS
+keyring.
+
+Design goals are:
+
+ * [ ] Destroy and re-create the resources in this module with minimal impact
+   to operations.
+ * [ ] Quick boot time to enable fast rolling upgrades and HA recovery
+ * [ ] Preemptible instance support with hand-off of active role to a standby
+ * [ ] Auto healing
+
+Auto-scaling is explicitly not a design goal at this time.

--- a/modules/55_vault_cluster/main.tf
+++ b/modules/55_vault_cluster/main.tf
@@ -1,0 +1,299 @@
+/**
+ * Copyright 2020 Open Infrastructure Services, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+locals {
+  service_account_email = var.service_account_email == null ? "vault-server@${var.project_id}.iam.gserviceaccount.com" : var.service_account_email
+  api_addr              = var.api_addr == null ? "https://${var.vault_cluster_address}:${var.vault_port}" : var.api_addr
+  vault_tls_bucket      = var.vault_tls_bucket == null ? var.vault_storage_bucket : var.vault_tls_bucket
+  vault_kms_key_tls     = var.vault_kms_key_tls == null ? var.vault_kms_key_init : var.vault_kms_key_tls
+
+  # Vault needs these broken down
+  # vault_kms_keyring: projects/v6-vault-f295/locations/us-west1/keyRings/vault-9f1f
+  vault_kms_key_init_project   = split("/", var.vault_kms_key_init)[1]
+  vault_kms_key_init_location  = split("/", var.vault_kms_key_init)[3]
+  vault_kms_key_init_keyring   = split("/", var.vault_kms_key_init)[5]
+  vault_kms_key_init_cryptokey = split("/", var.vault_kms_key_init)[7]
+
+  # TLS values
+  vault_kms_key_tls_project   = split("/", local.vault_kms_key_tls)[1]
+  vault_kms_key_tls_location  = split("/", local.vault_kms_key_tls)[3]
+  vault_kms_key_tls_keyring   = split("/", local.vault_kms_key_tls)[5]
+  vault_kms_key_tls_cryptokey = split("/", local.vault_kms_key_tls)[7]
+
+  # Internal or External load balancer is supported, but not both at once.
+  lb_scheme         = upper(var.load_balancing_scheme)
+  use_internal_lb   = local.lb_scheme == "INTERNAL"
+  use_external_lb   = local.lb_scheme == "EXTERNAL"
+  # LB and Autohealing health checks have different behavior.  The load
+  # balancer shouldn't route traffic to a secondary vault instance, but it
+  # should consider the instance healthy for autohealing purposes.
+  # See: https://www.vaultproject.io/api-docs/system/health
+  hc_workload_request_path = "/v1/sys/health?uninitcode=200"
+  hc_autoheal_request_path = "/v1/sys/health?uninitcode=200&standbyok=true"
+
+  # Health Check intervals for load balancer health checks.  These are
+  # intentionally more agressive then auto-healing health checks.
+  check_interval_sec  = 5
+  timeout_sec         = 2
+  healthy_threshold   = 1
+  unhealthy_threshold = 2
+
+  # Default to all zones in the region unless zones were provided.
+  zones = length(var.zones) > 0 ? var.zones : data.google_compute_zones.available.names
+}
+
+data "google_compute_zones" "available" {
+  project = var.project_id
+  region  = var.region
+}
+
+resource "google_compute_instance_template" "vault" {
+  project      = var.project_id
+  region       = var.region
+  name_prefix  = "${var.name_prefix}${var.name_suffix}"
+  machine_type = var.machine_type
+  tags         = var.vault_instance_tags
+  labels       = var.vault_instance_labels
+
+  network_interface {
+    subnetwork = var.subnetwork
+  }
+
+  disk {
+    source_image = var.vault_instance_base_image
+    type         = "PERSISTENT"
+    disk_type    = var.disk_type
+    mode         = "READ_WRITE"
+    boot         = true
+    auto_delete  = true
+    disk_size_gb = var.disk_size_gb
+  }
+
+  service_account {
+    email  = local.service_account_email
+    scopes = ["cloud-platform"]
+  }
+
+  metadata = merge(
+    var.vault_instance_metadata,
+    {
+      "google-compute-enable-virtio-rng" = "true"
+      "startup-script"                   = data.template_file.vault-startup-script.rendered
+      "shutdown-script"                  = data.template_file.vault-shutdown-script.rendered
+    },
+  )
+
+  scheduling {
+    preemptible       = var.preemptible
+    automatic_restart = var.preemptible ? false : true
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+data "template_file" "vault-startup-script" {
+  template = file("${path.module}/templates/startup.sh.tpl")
+
+  vars = {
+    # Vars passed to startup script
+    config                  = data.template_file.vault-config.rendered
+    service_account_email   = local.service_account_email
+    vault_args              = var.vault_args
+    vault_port              = var.vault_port
+    vault_version           = var.vault_version
+    vault_tls_bucket        = local.vault_tls_bucket
+    vault_ca_cert_filename  = var.vault_ca_cert_filename
+    vault_tls_key_filename  = var.vault_tls_key_filename
+    vault_tls_cert_filename = var.vault_tls_cert_filename
+    http_proxy              = var.http_proxy
+
+    vault_kms_key_tls_project = local.vault_kms_key_tls_project
+    vault_kms_key_tls         = local.vault_kms_key_tls
+    user_startup_script       = var.user_startup_script
+  }
+}
+
+data "template_file" "vault-shutdown-script" {
+  template = file("${path.module}/templates/shutdown.sh.tpl")
+}
+
+data "template_file" "vault-config" {
+  template = file(format("%s/templates/config.hcl.tpl", path.module))
+
+  vars = {
+    # Vars passed to vault config file
+    api_addr                                 = local.api_addr
+    vault_kms_key_init_project               = local.vault_kms_key_init_project
+    vault_kms_key_init_location              = local.vault_kms_key_init_location
+    vault_kms_key_init_keyring               = local.vault_kms_key_init_keyring
+    vault_kms_key_init_cryptokey             = local.vault_kms_key_init_cryptokey
+    vault_storage_bucket                     = var.vault_storage_bucket
+    vault_cluster_address                    = var.vault_cluster_address
+    vault_port                               = var.vault_port
+    vault_log_level                          = var.vault_log_level
+    vault_tls_disable_client_certs           = var.vault_tls_disable_client_certs
+    vault_tls_require_and_verify_client_cert = var.vault_tls_require_and_verify_client_cert
+    vault_ui_enabled                         = var.vault_ui_enabled
+  }
+}
+
+############################
+## Internal Load Balancer ##
+############################
+
+resource "google_compute_health_check" "ilb" {
+  count   = local.use_internal_lb ? 1 : 0
+  project = var.project_id
+  name    = "vault-ilb${var.name_suffix}"
+
+  check_interval_sec  = local.check_interval_sec
+  timeout_sec         = local.timeout_sec
+  healthy_threshold   = local.healthy_threshold
+  unhealthy_threshold = local.unhealthy_threshold
+
+  https_health_check {
+    port         = var.vault_port
+    request_path = local.hc_workload_request_path
+  }
+}
+
+resource "google_compute_region_backend_service" "vault_internal" {
+  count         = local.use_internal_lb ? 1 : 0
+  project       = var.project_id
+  name          = "vault${var.name_suffix}"
+  region        = var.region
+  health_checks = [google_compute_health_check.ilb[0].self_link]
+
+  backend {
+    group = google_compute_region_instance_group_manager.vault.instance_group
+  }
+}
+
+resource "google_compute_forwarding_rule" "ilb" {
+  count                 = local.use_internal_lb ? 1 : 0
+  project               = var.project_id
+  name                  = "vault-ilb${var.name_suffix}"
+  region                = var.region
+  ip_protocol           = "TCP"
+  ip_address            = var.vault_cluster_address
+  load_balancing_scheme = local.lb_scheme
+  network_tier          = "PREMIUM"
+  allow_global_access   = true
+  subnetwork            = var.subnetwork
+  service_label         = var.service_label
+  backend_service       = google_compute_region_backend_service.vault_internal[0].self_link
+}
+
+############################
+## External Load Balancer ##
+############################
+
+resource "google_compute_http_health_check" "elb" {
+  count   = local.use_external_lb ? 1 : 0
+  project = var.project_id
+  name    = "vault-elb${var.name_suffix}"
+
+  check_interval_sec  = local.check_interval_sec
+  timeout_sec         = local.timeout_sec
+  healthy_threshold   = local.healthy_threshold
+  unhealthy_threshold = local.unhealthy_threshold
+  # This port aligns with the http only listener in the config.hcl file.
+  port                = 8210
+  request_path        = local.hc_workload_request_path
+}
+
+resource "google_compute_target_pool" "vault" {
+  count   = local.use_external_lb ? 1 : 0
+  project = var.project_id
+
+  name   = "vault${var.name_suffix}"
+  region = var.region
+
+  health_checks = [google_compute_http_health_check.elb[0].name]
+}
+
+resource "google_compute_forwarding_rule" "elb" {
+  count   = local.use_external_lb ? 1 : 0
+  project = var.project_id
+
+  name                  = "vault-elb${var.name_suffix}"
+  region                = var.region
+  ip_address            = var.vault_cluster_address
+  ip_protocol           = "TCP"
+  load_balancing_scheme = local.lb_scheme
+  network_tier          = "PREMIUM"
+  port_range            = "1-65535"
+  target                = google_compute_target_pool.vault[0].self_link
+}
+
+############################
+## Managed Instance Group ##
+############################
+
+resource "google_compute_health_check" "autoheal" {
+  project = var.project_id
+  name    = "vault-health-autoheal${var.name_suffix}"
+
+  check_interval_sec  = 10
+  timeout_sec         = 5
+  healthy_threshold   = 1
+  unhealthy_threshold = 2
+
+  https_health_check {
+    port         = var.vault_port
+    request_path = local.hc_autoheal_request_path
+  }
+}
+
+resource "google_compute_region_instance_group_manager" "vault" {
+  project                   = var.project_id
+  name                      = "vault${var.name_suffix}"
+  region                    = var.region
+  base_instance_name        = "vault${var.name_suffix}"
+  distribution_policy_zones = local.zones
+  target_size               = var.num_instances
+  wait_for_instances        = false
+
+  auto_healing_policies {
+    health_check      = google_compute_health_check.autoheal.id
+    initial_delay_sec = var.hc_initial_delay_secs
+  }
+
+  update_policy {
+    type                  = "OPPORTUNISTIC"
+    minimal_action        = "REPLACE"
+    max_unavailable_fixed = length(local.zones)
+    min_ready_sec         = var.min_ready_sec
+  }
+
+  target_pools = local.use_external_lb ? [google_compute_target_pool.vault[0].self_link] : []
+
+  named_port {
+    name = "vault-ui"
+    port = 443
+  }
+
+  named_port {
+    name = "vault-api"
+    port = var.vault_port
+  }
+
+  version {
+    instance_template = google_compute_instance_template.vault.self_link
+  }
+}

--- a/modules/55_vault_cluster/templates/config.hcl.tpl
+++ b/modules/55_vault_cluster/templates/config.hcl.tpl
@@ -1,0 +1,71 @@
+# Run Vault in HA mode. Even if there's only one Vault node, it doesn't hurt to
+# have this set.
+api_addr     = "${api_addr}"
+# LOCAL_IP is replaced with the eth0 IP address by the startup script.
+cluster_addr = "https://LOCAL_IP:8201"
+
+# Set debugging level
+log_level = "${vault_log_level}"
+
+# Enable the UI
+ui = ${vault_ui_enabled ? true : false}
+
+# Enable plugin directory
+plugin_directory = "/etc/vault.d/plugins"
+
+# Enable auto-unsealing with Google Cloud KMS
+seal "gcpckms" {
+  project    = "${vault_kms_key_init_project}"
+  region     = "${vault_kms_key_init_location}"
+  key_ring   = "${vault_kms_key_init_keyring}"
+  crypto_key = "${vault_kms_key_init_cryptokey}"
+}
+
+# Enable HA backend storage with GCS
+storage "gcs" {
+  bucket     = "${vault_storage_bucket}"
+  ha_enabled = "true"
+}
+
+# Create local non-TLS listener
+listener "tcp" {
+  address     = "127.0.0.1:${vault_port}"
+  tls_disable = 1
+}
+
+# Create non-TLS listener for the HTTP legacy health checks.  Make sure the VPC
+# firewall doesn't allow traffic to this port except from the probe IP range.
+listener "tcp" {
+  address     = "${vault_cluster_address}:8210"
+  tls_disable = 1
+}
+
+# Create an mTLS listener on the load balancer address
+listener "tcp" {
+  address            = "${vault_cluster_address}:${vault_port}"
+  tls_cert_file      = "/etc/vault.d/tls/vault.crt"
+  tls_key_file       = "/etc/vault.d/tls/vault.key"
+  tls_client_ca_file = "/etc/vault.d/tls/ca.crt"
+
+  tls_disable_client_certs           = "${vault_tls_disable_client_certs}"
+  tls_require_and_verify_client_cert = "${vault_tls_require_and_verify_client_cert}"
+}
+
+# Create an mTLS listener locally. Client's shouldn't talk to Vault directly,
+# but not all clients are well-behaved. This is also needed so the cluster
+# nodes can communicate with each other.
+listener "tcp" {
+  address            = "LOCAL_IP:${vault_port}"
+  tls_cert_file      = "/etc/vault.d/tls/vault.crt"
+  tls_key_file       = "/etc/vault.d/tls/vault.key"
+  tls_client_ca_file = "/etc/vault.d/tls/ca.crt"
+
+  tls_disable_client_certs           = "${vault_tls_disable_client_certs}"
+  tls_require_and_verify_client_cert = "${vault_tls_require_and_verify_client_cert}"
+}
+
+# Send data to statsd (Stackdriver monitoring)
+telemetry {
+  statsd_address   = "127.0.0.1:8125"
+  disable_hostname = true
+}

--- a/modules/55_vault_cluster/templates/shutdown.sh.tpl
+++ b/modules/55_vault_cluster/templates/shutdown.sh.tpl
@@ -1,0 +1,13 @@
+#! /bin/bash
+#
+# This script uses the 30 second shutdown window on preemption to block traffic
+# from the load balancer health check while still processing any outstanding
+# requests.  Additionally, the active role is given up.
+
+# TODO: Execute vault operator step-down after authenticating.
+
+# Make the loadbalancer health check fail
+iptables -A INPUT -p tcp --dport 8210 -j REJECT
+# Sleep 20 seconds to finish processing any outsntanding requests.  The vault
+# service will be stopped after the google-shutdown-service.
+sleep 20

--- a/modules/55_vault_cluster/templates/startup.sh.tpl
+++ b/modules/55_vault_cluster/templates/startup.sh.tpl
@@ -1,0 +1,289 @@
+#! /usr/bin/env bash
+
+set -xe
+set -o pipefail
+
+# Direct TCP 443 to the Vault port.  Note this only works for connections from
+# other hosts.  This is intended to expose the Vault UI through Cloudflare,
+# which only proxies certain ports, 443 and 8443 included.
+iptables -t nat -A PREROUTING -p tcp --dport 443 -j REDIRECT --to-ports ${vault_port}
+
+# Only run the script once
+if [ -f ~/.startup-script-complete ]; then
+  echo "Startup script already ran, exiting"
+  exit 0
+fi
+
+# Data
+LOCAL_IP="$(curl -sf -H "Metadata-Flavor: Google" http://metadata/computeMetadata/v1/instance/network-interfaces/0/ip)"
+
+# Allow users to specify an HTTP proxy for egress instead of a NAT
+if [[ ! -z '${http_proxy}' ]]; then
+  export http_proxy='${http_proxy}'
+  export https_proxy="$http_proxy"
+fi
+
+# Get Vault up and running as quickly as possible to get the auto-heal health
+# check passing.  This results in faster recovery and faster rolling upgrades.
+
+# Deps
+export DEBIAN_FRONTEND=noninteractive
+# apt-get upgrade -yqq
+# apt-get install -yqq jq libcap2-bin logrotate unzip
+
+# Download and install Vault
+curl -sLfo /tmp/vault.zip "https://releases.hashicorp.com/vault/${vault_version}/vault_${vault_version}_linux_amd64.zip"
+# Unzip without having to apt install unzip
+(echo "import sys"; echo "import zipfile"; echo "with zipfile.ZipFile(sys.argv[1]) as z:"; echo '  z.extractall("/tmp")') | python3 - /tmp/vault.zip
+install -o0 -g0 -m0755 -D /tmp/vault /usr/local/bin/vault
+rm /tmp/vault.zip /tmp/vault
+
+# Give Vault the ability to run mlock as non-root
+/sbin/setcap cap_ipc_lock=+ep /usr/local/bin/vault
+
+# Add Vault user
+useradd -d /etc/vault.d -s /bin/false vault
+
+# Vault config
+mkdir -p /etc/vault.d
+mkdir /etc/vault.d/plugins
+cat <<"EOF" > /etc/vault.d/config.hcl
+${config}
+EOF
+chmod 0600 /etc/vault.d/config.hcl
+
+# Sub in local IP
+# $$ is correct here because we are in terraform template
+sed -i "s/LOCAL_IP/$${LOCAL_IP}/g" /etc/vault.d/config.hcl
+
+# Service environment
+cat <<"EOF" > /etc/vault.d/vault.env
+VAULT_ARGS=${vault_args}
+EOF
+chmod 0600 /etc/vault.d/vault.env
+
+# Download TLS files from GCS
+mkdir -p /etc/vault.d/tls
+gsutil cp "gs://${vault_tls_bucket}/${vault_ca_cert_filename}" /etc/vault.d/tls/ca.crt
+gsutil cp "gs://${vault_tls_bucket}/${vault_tls_cert_filename}" /etc/vault.d/tls/vault.crt
+gsutil cp "gs://${vault_tls_bucket}/${vault_tls_key_filename}" /etc/vault.d/tls/vault.key.enc
+
+# Decrypt the Vault private key
+base64 --decode < /etc/vault.d/tls/vault.key.enc | gcloud kms decrypt \
+  --project="${vault_kms_key_tls_project}" \
+  --key="${vault_kms_key_tls}" \
+  --plaintext-file=/etc/vault.d/tls/vault.key \
+  --ciphertext-file=-
+
+# Make sure Vault owns everything
+chmod 700 /etc/vault.d/tls
+chmod 600 /etc/vault.d/tls/vault.key
+chown -R vault:vault /etc/vault.d
+rm /etc/vault.d/tls/vault.key.enc
+
+# Make audit files
+mkdir -p /var/log/vault
+touch /var/log/vault/{audit,server}.log
+chmod 0640 /var/log/vault/{audit,server}.log
+chown -R vault:adm /var/log/vault
+
+# Add the TLS ca.crt to the trusted store so plugins dont error with TLS
+# handshakes
+cp /etc/vault.d/tls/ca.crt /usr/local/share/ca-certificates/
+update-ca-certificates
+
+# Systemd service
+cat <<"EOF" > /etc/systemd/system/vault.service
+[Unit]
+Description="HashiCorp Vault"
+Documentation=https://www.vaultproject.io/docs/
+Requires=network-online.target
+After=network-online.target
+# Stop after the shutdown script stops.
+Before=google-shutdown-scripts.service
+ConditionFileNotEmpty=/etc/vault.d/config.hcl
+
+[Service]
+User=vault
+Group=vault
+ProtectSystem=full
+ProtectHome=read-only
+PrivateTmp=yes
+PrivateDevices=yes
+SecureBits=keep-caps
+StandardError=syslog
+StandardOutput=syslog
+SyslogIdentifier=vault
+AmbientCapabilities=CAP_IPC_LOCK
+CapabilityBoundingSet=CAP_SYSLOG CAP_IPC_LOCK
+NoNewPrivileges=yes
+EnvironmentFile=/etc/vault.d/vault.env
+ExecStart=/usr/local/bin/vault server -config=/etc/vault.d/config.hcl $VAULT_ARGS
+ExecReload=/bin/kill --signal HUP $MAINPID
+KillMode=process
+KillSignal=SIGINT
+Restart=on-failure
+RestartSec=5
+TimeoutStopSec=30
+
+[Install]
+WantedBy=multi-user.target
+EOF
+chmod 0644 /etc/systemd/system/vault.service
+systemctl daemon-reload
+systemctl restart vault
+
+## AT THIS POINT VAULT HEALTH CHECKS SHOULD START PASSING
+
+# Prevent core dumps - from all attack vectors
+cat <<"EOF" > /etc/sysctl.d/50-coredump.conf
+kernel.core_pattern=|/bin/false
+EOF
+sysctl -p /etc/sysctl.d/50-coredump.conf
+
+cat <<"EOF" > /etc/security/limits.conf
+* hard core 0
+EOF
+
+mkdir -p /etc/systemd/coredump.conf.d
+cat <<"EOF" > /etc/systemd/coredump.conf.d/disable.conf
+[Coredump]
+Storage=none
+EOF
+
+cat <<"EOF" >> /etc/sysctl.conf
+fs.suid_dumpable = 0
+EOF
+sysctl -p
+
+cat <<"EOF" > /etc/profile.d/ulimit.sh
+ulimit -S -c 0 > /dev/null  2>&1
+EOF
+source /etc/profile.d/ulimit.sh
+
+# Reload any systemd changes for core dumps
+systemctl daemon-reload
+
+# Setup vault env
+cat <<"EOF" > /etc/profile.d/vault.sh
+export VAULT_ADDR="http://127.0.0.1:${vault_port}"
+
+# Ignore history from any Vault commands
+export HISTIGNORE="&:vault*"
+EOF
+chmod 644 /etc/profile.d/vault.sh
+source /etc/profile.d/vault.sh
+
+# Pull Vault data from syslog into a file for fluentd
+cat <<"EOF" > /etc/rsyslog.d/vault.conf
+#
+# Extract Vault logs from syslog
+#
+
+# Only include the message (Vault has its own timestamps and data)
+template(name="OnlyMsg" type="string" string="%msg:2:$:drop-last-lf%\n")
+
+if ( $programname == "vault" ) then {
+  action(type="omfile" file="/var/log/vault/server.log" template="OnlyMsg")
+  stop
+}
+EOF
+systemctl restart rsyslog
+
+# Install Stackdriver for logging and monitoring
+# Logging Agent: https://cloud.google.com/logging/docs/agent/installation
+curl -sSfL https://dl.google.com/cloudagents/add-logging-agent-repo.sh | bash
+# Monitoring Agent: https://cloud.google.com/monitoring/agent/installation
+curl -sSfL https://dl.google.com/cloudagents/add-monitoring-agent-repo.sh | bash
+apt-get update -yqq
+# Install structured logs
+apt-get install -yqq 'stackdriver-agent=6.*' 'google-fluentd=1.*' google-fluentd-catch-all-config-structured
+
+# Start Stackdriver logging agent and setup the filesystem to be ready to
+# receive audit logs
+mkdir -p /etc/google-fluentd/config.d
+cat <<"EOF" > /etc/google-fluentd/config.d/vaultproject.io.conf
+<source>
+  @type tail
+  format json
+
+  time_type "string"
+  time_format "%Y-%m-%dT%H:%M:%S.%N%z"
+  keep_time_key true
+
+  path /var/log/vault/audit.log
+  pos_file /var/lib/google-fluentd/pos/vault.audit.pos
+  read_from_head true
+  tag vaultproject.io/audit
+</source>
+
+<filter vaultproject.io/audit>
+  @type record_transformer
+  enable_ruby true
+  <record>
+    message "$${record.dig('request', 'id') || '-'} $${record.dig('request', 'remote_address') || '-'} $${record.dig('auth', 'display_name') || '-'} $${record.dig('request', 'operation') || '-'} $${record.dig('request', 'path') || '-'}"
+    host "#{Socket.gethostname}"
+  </record>
+</filter>
+
+<source>
+  @type tail
+  format /^(?<time>[^ ]+) \[(?<severity>[^ ]+)\][ ]+(?<source>[^:]+): (?<message>.*)/
+
+  time_type "string"
+  time_format "%Y-%m-%dT%H:%M:%S.%N%z"
+  keep_time_key true
+
+  path /var/log/vault/server.log
+  pos_file /var/lib/google-fluentd/pos/vault.server.pos
+  read_from_head true
+  tag vaultproject.io/server
+</source>
+
+<filter vaultproject.io/server>
+  @type record_transformer
+  enable_ruby true
+  <record>
+    message "$${record['source']}: $${record['message']}"
+    severity "$${(record['severity'] || '').downcase}"
+    host "#{Socket.gethostname}"
+  </record>
+</filter>
+EOF
+systemctl enable google-fluentd
+systemctl restart google-fluentd
+
+# Configure logrotate for Vault audit logs
+mkdir -p /etc/logrotate.d
+cat <<"EOF" > /etc/logrotate.d/vaultproject.io
+/var/log/vault/*.log {
+  daily
+  rotate 3
+  missingok
+  compress
+  notifempty
+  create 0640 vault adm
+  sharedscripts
+  postrotate
+    kill -HUP $(pidof vault)
+    true
+  endscript
+}
+EOF
+
+# Start Stackdriver monitoring
+mkdir -p /opt/stackdriver/collectd/etc/collectd.d
+curl -sSfLo /opt/stackdriver/collectd/etc/collectd.d/statsd.conf \
+  https://raw.githubusercontent.com/Stackdriver/stackdriver-agent-service-configs/master/etc/collectd.d/statsd.conf
+service stackdriver-agent restart
+
+#########################################
+##          user_startup_script        ##
+#########################################
+${user_startup_script}
+
+# Signal this script has run
+touch ~/.startup-script-complete
+
+# Reboot to pick up system-level changes
+# sudo reboot

--- a/modules/55_vault_cluster/variables.tf
+++ b/modules/55_vault_cluster/variables.tf
@@ -1,0 +1,237 @@
+/**
+ * Copyright 2020 Open Infrastructure Services, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "project_id" {
+  description = "Project ID to contain managed resources."
+  type        = string
+}
+
+variable "region" {
+  description = "Region in which to create resources."
+  type        = string
+}
+
+variable "name_prefix" {
+  description = "The name prefix to us for managed resources, for example 'vault'.  Intended for major version upgrades of the module.  Use a unique value for each region.  See also UPGRADE.md for major version upgrades."
+  type        = string
+  default     = "vault"
+}
+
+variable "vault_instance_base_image" {
+  description = "Base operating system image in which to install Vault. This must be a Debian-based system at the moment due to how the metadata startup script runs."
+  type        = string
+  default     = "debian-cloud/debian-10"
+}
+
+variable "machine_type" {
+  description = "The machine type used with the instance template https://cloud.google.com/compute/docs/machine-types"
+  type        = string
+  default     = "n1-standard-1"
+}
+
+variable "preemptible" {
+  description = "Allows instance to be preempted. This defaults to false. See https://cloud.google.com/compute/docs/instances/preemptible"
+  type        = bool
+  default     = false
+}
+
+variable "num_instances" {
+  description = "The number of instances in the instance group"
+  type        = number
+  default     = 1
+}
+
+variable "min_ready_sec" {
+  description = "Minimum number of seconds to wait for after a newly created instance becomes available. This value must be from range. [0,3600]"
+  type        = number
+  default     = 60
+}
+
+variable "hc_initial_delay_secs" {
+  description = "The number of seconds that the managed instance group waits before it applies autohealing policies to new instances or recently recreated instances."
+  type        = number
+  default     = 60
+}
+
+variable "zones" {
+  description = "The zones to distribute instances across.  If empty, all zones in the region are used.  ['us-west1-a', 'us-west1-b', 'us-west1-c']"
+  type        = list(string)
+  default     = []
+}
+
+variable "disk_type" {
+  description = "The persistent disk type to use with the vault server instance template.  See https://www.terraform.io/docs/providers/google/r/compute_instance_template.html#disk_type"
+  type        = string
+  default     = "pd-standard"
+}
+
+variable "disk_size_gb" {
+  description = "The size in GB of the persistent disk attached to each multinic instance.  The source_image size is used if unspecified."
+  type        = string
+  default     = null
+}
+
+variable "vault_port" {
+  description = "Numeric port on which to run and expose Vault."
+  type        = number
+  default     = 8200
+}
+
+variable "vault_tls_disable_client_certs" {
+  description = "Use client certificates when provided. You may want to disable this if users will not be authenticating to Vault with client certificates."
+  type        = bool
+  default     = false
+}
+
+variable "vault_tls_require_and_verify_client_cert" {
+  description = "Always use client certificates. You may want to disable this if users will not be authenticating to Vault with client certificates."
+  type        = bool
+  default     = false
+}
+
+variable "vault_storage_bucket" {
+  description = "Storage bucket name where the backend is configured. This bucket will not be created in this module"
+  type        = string
+}
+
+variable "vault_tls_bucket" {
+  description = "GCS Bucket override where Vault will expect TLS certificates are stored.  The vault_storage_bucket is used if not provided."
+  type        = string
+  default     = null
+}
+
+variable "vault_ui_enabled" {
+  description = "Controls whether the Vault UI is enabled and accessible."
+  type        = bool
+  default     = true
+}
+
+variable "vault_version" {
+  description = "Version of vault to install. This version must be 1.0+ and must be published on the HashiCorp releases service."
+  type        = string
+  default     = "1.5.4"
+}
+
+variable "user_startup_script" {
+  description = "Additional user-provided code injected after Vault is setup"
+  type        = string
+  default     = ""
+}
+
+variable "service_account_email" {
+  description = "The service account bound to the compute instances.  vault-server@PROJECT_ID.iam.gserviceaccount.com is used if not provided."
+  type        = string
+  default     = null
+}
+
+variable "vault_args" {
+  description = "Additional command line arguments passed to Vault server"
+  type        = string
+  default     = ""
+}
+
+variable "vault_ca_cert_filename" {
+  description = "GCS object path within the vault_tls_bucket. This is the root CA certificate."
+  type        = string
+  default     = "ca.crt"
+}
+
+variable "vault_tls_cert_filename" {
+  description = "GCS object path within the vault_tls_bucket. This is the vault server certificate."
+  type        = string
+  default     = "vault.crt"
+}
+
+variable "vault_tls_key_filename" {
+  description = "Encrypted and base64 encoded GCS object path within the vault_tls_bucket. This is the Vault TLS private key."
+  type        = string
+  default     = "vault.key.enc"
+}
+
+variable "vault_kms_key_init" {
+  description = "KMS Crypto key specific for seal and unseal.  Full path.  for example projects/vault/locations/us/keyRings/vault/cryptoKeys/vault-init"
+  type        = string
+}
+
+variable "vault_kms_key_tls" {
+  description = "KMS Crypto key specific for TLS decryption.  Full path.  If not specified, defaults to vault_kms_key_init."
+  type        = string
+  default     = null
+}
+
+variable "subnetwork" {
+  description = "The self link of the VPC subnet for Vault, must include the project and region in the URI."
+  type        = string
+}
+
+variable "http_proxy" {
+  description = "Optional HTTP proxy for downloading agents and vault executable on startup.  This is only used on the first startup of the Vault cluster and will NOT set the global HTTP_PROXY environment variable. i.e. If you configure Vault to manage credentials for other services, default HTTP routes will be taken."
+  type        = string
+  default     = ""
+}
+
+variable "api_addr" {
+  description = "The URI to access the vault API through the load balancer.  For example, https://vault.dev.ois.run:8443.  Defaults to https://var.vault_cluster_address:var.vault_port if not specified."
+  type        = string
+  default     = null
+}
+
+variable "vault_log_level" {
+  description = "Log level to run Vault in. See the Vault documentation for valid values."
+  type        = string
+  default     = "warn"
+}
+
+variable "vault_instance_labels" {
+  description = "Labels to apply to the Vault instances."
+  type        = map(string)
+  default     = {}
+}
+
+variable "vault_instance_tags" {
+  description = "Instance tags to apply to the vault instance, intended for use with firewall rules."
+  type        = list(string)
+  default     = ["allow-ssh", "allow-vault"]
+}
+
+variable "vault_instance_metadata" {
+  description = "Additional metadata to add to the Vault instances."
+  type        = map(string)
+  default     = {}
+}
+
+variable "vault_cluster_address" {
+  type        = string
+  description = "The IP address bound to forwarding rules.  The caller is expected to reserve an external or internal address with a google_compute_address resource and pass in the IP value here.  Example: 10.10.10.10"
+}
+
+variable "load_balancing_scheme" {
+  description = "Options are INTERNAL or EXTERNAL. If `EXTERNAL`, the forwarding rule will be of type EXTERNAL and the provided IP address must an an external address. If `INTERNAL` the type will be INTERNAL the provided address must be an internal IP address."
+  type        = string
+  default     = "EXTERNAL"
+}
+
+variable "service_label" {
+  type        = string
+  description = "The service label to set on the internal load balancer. If not empty, this enables internal DNS for internal load balancers. By default, the service label is disabled. This has no effect on external load balancers."
+  default     = null
+}
+
+variable "name_suffix" {
+  description = "A name suffix to append to all resources to allow multiple deployments in the same region. For example, -fab1"
+  type        = string
+  default     = ""
+}

--- a/modules/cluster/outputs.tf
+++ b/modules/cluster/outputs.tf
@@ -44,3 +44,8 @@ output "vault_lb_port" {
   value       = var.vault_port
   description = "Port where Vault is exposed on the load balancer."
 }
+
+output "instance_group" {
+  value       = google_compute_region_instance_group_manager.vault.instance_group
+  description = "The instance groups intended for use with a google_compute_region_backend_service resource"
+}

--- a/modules/cluster/variables.tf
+++ b/modules/cluster/variables.tf
@@ -15,23 +15,20 @@
  */
 
 variable "project_id" {
-  type = string
-
-  description = "ID of the project in which to create resources and add IAM bindings."
+  description = "Project ID to contain managed resources."
+  type        = string
 }
 
 variable "host_project_id" {
-  type    = string
-  default = ""
-
   description = "ID of the host project if using Shared VPC"
+  type        = string
+  default     = ""
 }
 
 variable "region" {
-  type    = string
-  default = "us-east4"
-
   description = "Region in which to create resources."
+  type        = string
+  default     = "us-east4"
 }
 
 variable "subnet" {
@@ -56,38 +53,8 @@ variable "vault_storage_bucket" {
 }
 
 variable "vault_service_account_email" {
-  type        = string
   description = "Vault service account email"
-}
-
-variable "service_account_project_iam_roles" {
-  type = list(string)
-
-  default = [
-    "roles/logging.logWriter",
-    "roles/monitoring.metricWriter",
-    "roles/monitoring.viewer",
-  ]
-
-  description = "List of IAM roles for the Vault admin service account to function. If you need to add additional roles, update `service_account_project_additional_iam_roles` instead."
-}
-
-variable "service_account_project_additional_iam_roles" {
-  type    = list(string)
-  default = []
-
-  description = "List of custom IAM roles to add to the project."
-}
-
-variable "service_account_storage_bucket_iam_roles" {
-  type = list(string)
-
-  default = [
-    "roles/storage.legacyBucketReader",
-    "roles/storage.objectAdmin",
-  ]
-
-  description = "List of IAM roles for the Vault admin service account to have on the storage bucket."
+  type        = string
 }
 
 #
@@ -96,98 +63,137 @@ variable "service_account_storage_bucket_iam_roles" {
 # --------------------
 
 variable "kms_keyring" {
-  type    = string
-  default = "vault"
-
-  description = "Name of the Cloud KMS KeyRing for asset encryption. Terraform will create this keyring."
-
+  description = "Name of the Cloud KMS KeyRing for unsealing vault and TLS keys."
+  type        = string
+  default     = "vault"
 }
 
 variable "kms_crypto_key" {
-  type    = string
-  default = "vault-init"
-
-  description = "The name of the Cloud KMS Key used for encrypting initial TLS certificates and for configuring Vault auto-unseal. Terraform will create this key."
-}
-
-variable "kms_protection_level" {
-  type    = string
-  default = "software"
-
-  description = "The protection level to use for the KMS crypto key."
+  description = "The name of the Cloud KMS Key used for encrypting initial TLS certificates and for configuring Vault auto-unseal."
+  type        = string
+  default     = "vault-init"
 }
 
 
 #TODO: Evaluate https://www.terraform.io/docs/configuration/variables.html#custom-validation-rules when prod ready
 variable "load_balancing_scheme" {
-  type    = string
-  default = "EXTERNAL"
-
   description = "Options are INTERNAL or EXTERNAL. If `EXTERNAL`, the forwarding rule will be of type EXTERNAL and a public IP will be created. If `INTERNAL` the type will be INTERNAL and a random RFC 1918 private IP will be assigned"
+  type        = string
+  default     = "EXTERNAL"
 }
 
 variable "vault_args" {
-  type    = string
-  default = ""
-
   description = "Additional command line arguments passed to Vault server"
+  type        = string
+  default     = ""
 }
 
 variable "vault_instance_labels" {
-  type    = map(string)
-  default = {}
-
   description = "Labels to apply to the Vault instances."
+  type        = map(string)
+  default     = {}
 }
 
 variable "vault_ca_cert_filename" {
-  type    = string
-  default = "ca.crt"
-
   description = "GCS object path within the vault_tls_bucket. This is the root CA certificate."
+  type        = string
+  default     = "ca.crt"
 }
 
 variable "vault_instance_metadata" {
-  type    = map(string)
-  default = {}
-
   description = "Additional metadata to add to the Vault instances."
+  type        = map(string)
+  default     = {}
 }
 
 variable "vault_instance_base_image" {
-  type    = string
-  default = "debian-cloud/debian-9"
-
   description = "Base operating system image in which to install Vault. This must be a Debian-based system at the moment due to how the metadata startup script runs."
+  type        = string
+  default     = "debian-cloud/debian-9"
 }
 
 variable "vault_instance_tags" {
-  type    = list(string)
-  default = []
-
   description = "Additional tags to apply to the instances. Note 'allow-ssh' and 'allow-vault' will be present on all instances."
+  type        = list(string)
+  default     = []
 }
 
 variable "vault_log_level" {
-  type    = string
-  default = "warn"
-
   description = "Log level to run Vault in. See the Vault documentation for valid values."
+  type        = string
+  default     = "warn"
 }
 
 variable "vault_min_num_servers" {
-  type    = string
-  default = "1"
-
   description = "Minimum number of Vault server nodes in the autoscaling group. The group will not have less than this number of nodes."
+  type        = string
+  default     = "1"
 }
 
 variable "vault_machine_type" {
-  type    = string
-  default = "n1-standard-1"
-
   description = "Machine type to use for Vault instances."
+  type        = string
+  default     = "n1-standard-1"
+}
 
+variable "preemptible" {
+  description = "Allows instance to be preempted. This defaults to false. See https://cloud.google.com/compute/docs/instances/preemptible"
+  type        = bool
+  default     = false
+}
+
+variable "autoscale" {
+  description = "Enable autoscaling default configuration.  For advanced configuration, set to false and manage your own google_compute_autoscaler resource with target set this module's instance_group.id output value."
+  type        = bool
+  default     = true
+}
+
+variable "num_instances" {
+  description = "The number of instances in the instance group"
+  type        = number
+  default     = 1
+}
+
+variable "hc_self_link" {
+  description = "The health check self link used for auto healing.  This health check may be reused with backend services.  If blank, a health check will be created."
+  type        = string
+  default     = ""
+}
+
+variable "hc_self_link_provided" {
+  description = "Use the provided hc_self_link for autohealing if true."
+  type        = bool
+  default     = false
+}
+
+variable "min_ready_sec" {
+  description = "Minimum number of seconds to wait for after a newly created instance becomes available. This value must be from range. [0,3600]"
+  type        = string
+  default     = "300"
+}
+
+variable "zones" {
+  description = "The zones to distribute instances across.  If empty, all zones in the region are used.  ['us-west1-a', 'us-west1-b', 'us-west1-c']"
+  type        = list(string)
+  default     = []
+}
+
+variable "disk_type" {
+  description = "The persistent disk type to use with the vault server instance template.  See https://www.terraform.io/docs/providers/google/r/compute_instance_template.html#disk_type"
+  type        = string
+  default     = "pd-ssd"
+}
+
+variable "disk_size_gb" {
+  description = "The size in GB of the persistent disk attached to each multinic instance.  The source_image size is used if unspecified."
+  type        = string
+  default     = null
+}
+
+variable "hc_initial_delay_secs" {
+  description = "The number of seconds that the managed instance group waits before it applies autohealing policies to new instances or recently recreated instances."
+  type        = number
+  default     = 60
 }
 
 variable "vault_max_num_servers" {


### PR DESCRIPTION
This patch adds the following support, preserving default behavior.

 * Preemptible instances
 * Disk type and size selection
 * Instance group distribution policy
 * Auto-healing
 * Disable auto-scaling

Why allow auto-scaling to be turned off?

Because it causes problems with resizing:

```
gcloud compute instance-groups managed resize vault-igm --region us-west1 --size=0
ERROR: (gcloud.compute.instance-groups.managed.resize) Could not fetch resource:
 - Resizing of autoscaled regional managed instance groups is not allowed. If you want to manually adjust target size remove the autoscaler or set autoscaling policy mode to OFF.
```