### PR TITLE
Vault step-down on shutdown

### DIFF
--- a/modules/42_vault_iam/main.tf
+++ b/modules/42_vault_iam/main.tf
@@ -59,6 +59,14 @@ resource "google_kms_key_ring_iam_member" "ck-iam" {
   member      = local.service_account_member
 }
 
+# Grant Vault the ability to create JWT tokens for itself.  This enables the
+# shutdown script to login to Vault and execute vault operator step-down
+resource "google_service_account_iam_member" "vault_server_TokenCreator" {
+  service_account_id = "projects/-/serviceAccounts/${var.vault_service_account_email}"
+  role               = "roles/iam.serviceAccountTokenCreator"
+  member             = "serviceAccount:${var.vault_service_account_email}"
+}
+
 resource "google_storage_bucket_iam_member" "bucket-iam" {
   for_each = toset(local.tls_buckets)
   bucket   = each.value

--- a/modules/55_vault_cluster/templates/shutdown.sh.tpl
+++ b/modules/55_vault_cluster/templates/shutdown.sh.tpl
@@ -4,10 +4,28 @@
 # from the load balancer health check while still processing any outstanding
 # requests.  Additionally, the active role is given up.
 
-# TODO: Execute vault operator step-down after authenticating.
+export PATH="/usr/local/bin:$${PATH}"
 
 # Make the loadbalancer health check fail
 iptables -A INPUT -p tcp --dport 8210 -j REJECT
+
+export VAULT_ADDR="http://127.0.0.1:8200"
+
+# Get the service account email
+service_account="$(curl -sf -H Metadata-Flavor:Google metadata/computeMetadata/v1/instance/service-accounts/default/email)"
+domain="$${service_account##*@}"
+project="$${domain%%.*}"
+
+# Login to vault using the vault-server google service account.
+vault login -method=gcp \
+    role="step-down" \
+    service_account="$${service_account}" \
+    project="$${project}" \
+    jwt_exp="15m"
+
+# Hand off the active role to the other node in the cluster
+vault operator step-down
+
 # Sleep 20 seconds to finish processing any outsntanding requests.  The vault
 # service will be stopped after the google-shutdown-service.
 sleep 20


### PR DESCRIPTION
Hand off the active role to another instance on shutdown.  This improves
availability during rolling updates and preemption.

See: https://github.com/openinfrastructure/platform/issues/30
